### PR TITLE
Assets input

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+  experimental: {
+    esmExternals: false,
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@hookform/resolvers": "^3.2.0",
         "@radix-ui/react-accordion": "^1.1.2",
+        "@radix-ui/react-context-menu": "^2.1.4",
+        "@radix-ui/react-dropdown-menu": "^2.0.5",
         "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-popover": "^1.0.6",
         "@radix-ui/react-scroll-area": "^1.0.4",
@@ -38,6 +40,7 @@
         "react-hook-form": "^7.45.4",
         "react-icons": "^4.10.1",
         "react-query": "^3.39.3",
+        "react-rnd": "^10.4.1",
         "tailwind-merge": "^1.14.0",
         "tailwindcss": "3.3.3",
         "tailwindcss-animate": "^1.0.6",
@@ -592,6 +595,34 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-context-menu": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.1.4.tgz",
+      "integrity": "sha512-HVHLUtZOBiR2Fh5l07qQ9y0IgX4dGZF0S9Gwdk4CVA+DL9afSphvFNa4nRiw6RNgb6quwLV4dLPF/gFDvNaOcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-menu": "2.0.5",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz",
@@ -620,6 +651,35 @@
         "@radix-ui/react-primitive": "1.0.3",
         "@radix-ui/react-use-callback-ref": "1.0.1",
         "@radix-ui/react-use-escape-keydown": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.0.5.tgz",
+      "integrity": "sha512-xdOrZzOTocqqkCkYo8yRPCib5OkTkqN7lqNCdxwPOdE466DOaNl4N8PkUIlsXthQvW5Wwkd+aEmWpfWlBoDPEw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-menu": "2.0.5",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -703,6 +763,46 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.0.5.tgz",
+      "integrity": "sha512-Gw4f9pwdH+w5w+49k0gLjN0PfRDHvxmAgG16AbyJZ7zhwZ6PBHKtWohvnSwfusfnK3L68dpBREHpVkj8wEM7ZA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.4",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.3",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.2",
+        "@radix-ui/react-portal": "1.0.3",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-roving-focus": "1.0.4",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -842,6 +942,37 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz",
+      "integrity": "sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2613,6 +2744,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
+    "node_modules/fast-memoize": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -4229,6 +4365,18 @@
         }
       ]
     },
+    "node_modules/re-resizable": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.6.tgz",
+      "integrity": "sha512-0xYKS5+Z0zk+vICQlcZW+g54CcJTTmHluA7JUUgvERDxnKAnytylcyPsA+BSFi759s5hPlHmBRegFrwXs2FuBQ==",
+      "dependencies": {
+        "fast-memoize": "^2.5.1"
+      },
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -4263,6 +4411,27 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-draggable": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.5.tgz",
+      "integrity": "sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-draggable/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react-dropzone": {
@@ -4378,6 +4547,25 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-rnd": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.4.1.tgz",
+      "integrity": "sha512-0m887AjQZr6p2ADLNnipquqsDq4XJu/uqVqI3zuoGD19tRm6uB83HmZWydtkilNp5EWsOHbLGF4IjWMdd5du8Q==",
+      "dependencies": {
+        "re-resizable": "6.9.6",
+        "react-draggable": "4.4.5",
+        "tslib": "2.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/react-rnd/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/react-style-singleton": {
       "version": "2.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.2.0",
+        "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-popover": "^1.0.6",
+        "@radix-ui/react-scroll-area": "^1.0.4",
         "@radix-ui/react-select": "^1.2.2",
         "@radix-ui/react-slot": "^1.0.2",
+        "@radix-ui/react-tooltip": "^1.0.6",
         "@types/node": "20.5.1",
         "@types/react": "18.2.20",
         "@types/react-dom": "18.2.7",
@@ -43,6 +46,9 @@
         "eslint-plugin-import": "^2.28.1",
         "prettier": "3.0.2",
         "prettier-plugin-tailwindcss": "^0.5.3"
+      },
+      "engines": {
+        "node": ">=18.16.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -438,6 +444,37 @@
         "@babel/runtime": "^7.13.10"
       }
     },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.1.2.tgz",
+      "integrity": "sha512-fDG7jcoNKVjSK6yfmuAs0EnPDro0WMXIhMtXdTBWqEioVW206ku+4Lw07e+13lUkFkpoEQ2PdeMIAGpdqEAmDg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collapsible": "1.0.3",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz",
@@ -445,6 +482,36 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.0.3.tgz",
+      "integrity": "sha512-UBmVDkmR6IvDsloHVN+3rtx4Mi5TFvylYXpluuv0f37dtaz3H99bp8No0LGXRigVpl3UAT4l9j6bIchh42S/Gg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -787,6 +854,37 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.0.4.tgz",
+      "integrity": "sha512-OIClwBkwPG+FKvC4OMTRaa/3cfD069nkKFFL/TQzRzaO42Ce5ivKU9VMKgT7UU6UIkjcQqKBrDOIzWtPGw6e6w==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-select": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-1.2.2.tgz",
@@ -844,6 +942,40 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.0.6.tgz",
+      "integrity": "sha512-DmNFOiwEc2UDigsYj6clJENma58OelxD24O4IODoZ+3sQc3Zb+L8w1EP+y9laTuKCLAysPw4fD6/v0j4KNV8rg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.2",
+        "@radix-ui/react-portal": "1.0.3",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/node": "20.5.1",
         "@types/react": "18.2.20",
         "@types/react-dom": "18.2.7",
+        "@uploadthing/react": "^5.3.0",
         "autoprefixer": "10.4.15",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
@@ -33,12 +34,15 @@
         "react": "18.2.0",
         "react-day-picker": "^8.8.1",
         "react-dom": "18.2.0",
+        "react-dropzone": "^14.2.3",
         "react-hook-form": "^7.45.4",
         "react-icons": "^4.10.1",
+        "react-query": "^3.39.3",
         "tailwind-merge": "^1.14.0",
         "tailwindcss": "3.3.3",
         "tailwindcss-animate": "^1.0.6",
         "typescript": "5.1.6",
+        "uploadthing": "^5.3.3",
         "zod": "^3.22.2"
       },
       "devDependencies": {
@@ -1282,6 +1286,39 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@uploadthing/mime-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@uploadthing/mime-types/-/mime-types-0.2.0.tgz",
+      "integrity": "sha512-nRcdyM622+GYT9SdaJIVLknqoc8i7krItinfuBPtvmPc+UNGDJ+pMkr4AatYp88cEc4iYtPlN8flJvZ3dNtgrg=="
+    },
+    "node_modules/@uploadthing/react": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@uploadthing/react/-/react-5.3.0.tgz",
+      "integrity": "sha512-B/LowwhOgcU/VBdxueF6dzHFoXNt4oLKDp6GOjMpHATHzWQ+eOlWM32f7NOpgQ0i5/vJPpilZ46OazccnEam6g==",
+      "dependencies": {
+        "@uploadthing/shared": "^5.2.0",
+        "tailwind-merge": "^1.13.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dropzone": "^14.2.3",
+        "uploadthing": "^5.0.0"
+      }
+    },
+    "node_modules/@uploadthing/shared": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@uploadthing/shared/-/shared-5.2.0.tgz",
+      "integrity": "sha512-Mn1oYFX1XIfpU0L69wwBwOUfWbCp7ixq+8kB9aFOqmvxey8crey4gEwgPEhixfR1h42XfD7dOHKY/nOs7kkGjw==",
+      "peerDependencies": {
+        "@uploadthing/mime-types": "^0.2.0",
+        "zod": "^3.21.4"
+      },
+      "peerDependenciesMeta": {
+        "@uploadthing/mime-types": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/acorn": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
@@ -1518,6 +1555,14 @@
         "has-symbols": "^1.0.3"
       }
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.15",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.15.tgz",
@@ -1586,6 +1631,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1612,6 +1665,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "node_modules/browserslist": {
@@ -1905,6 +1973,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -2557,6 +2630,17 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-selector": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
+      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/fill-range": {
@@ -3296,6 +3380,11 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3434,6 +3523,15 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3453,6 +3551,11 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -3486,6 +3589,14 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+      "dependencies": {
+        "big-integer": "^1.6.16"
       }
     },
     "node_modules/nanoid": {
@@ -3724,6 +3835,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -4149,6 +4265,22 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-dropzone": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
+      "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
+      "dependencies": {
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.6.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.45.4",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.45.4.tgz",
@@ -4176,6 +4308,31 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-query": {
+      "version": "3.39.3",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
+      "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.5.5",
@@ -4302,6 +4459,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
     },
     "node_modules/resolve": {
       "version": "1.22.4",
@@ -4899,6 +5061,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "dependencies": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
@@ -4926,6 +5097,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uploadthing": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/uploadthing/-/uploadthing-5.3.3.tgz",
+      "integrity": "sha512-tYg44gX7+4Tf5UBZTS0Cjx44l6DBI4kaPdFDH2jUuxDp1CyTxUBUaFNvsA1AqhxQsxi3ZR+pGD917tn6kbPp/w==",
+      "dependencies": {
+        "@uploadthing/mime-types": "^0.2.0",
+        "@uploadthing/shared": "^5.2.0"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/node": "20.5.1",
     "@types/react": "18.2.20",
     "@types/react-dom": "18.2.7",
+    "@uploadthing/react": "^5.3.0",
     "autoprefixer": "10.4.15",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
@@ -34,12 +35,15 @@
     "react": "18.2.0",
     "react-day-picker": "^8.8.1",
     "react-dom": "18.2.0",
+    "react-dropzone": "^14.2.3",
     "react-hook-form": "^7.45.4",
     "react-icons": "^4.10.1",
+    "react-query": "^3.39.3",
     "tailwind-merge": "^1.14.0",
     "tailwindcss": "3.3.3",
     "tailwindcss-animate": "^1.0.6",
     "typescript": "5.1.6",
+    "uploadthing": "^5.3.3",
     "zod": "^3.22.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,13 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.2.0",
+    "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.0.6",
+    "@radix-ui/react-scroll-area": "^1.0.4",
     "@radix-ui/react-select": "^1.2.2",
     "@radix-ui/react-slot": "^1.0.2",
+    "@radix-ui/react-tooltip": "^1.0.6",
     "@types/node": "20.5.1",
     "@types/react": "18.2.20",
     "@types/react-dom": "18.2.7",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@hookform/resolvers": "^3.2.0",
     "@radix-ui/react-accordion": "^1.1.2",
+    "@radix-ui/react-context-menu": "^2.1.4",
+    "@radix-ui/react-dropdown-menu": "^2.0.5",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.0.6",
     "@radix-ui/react-scroll-area": "^1.0.4",
@@ -39,6 +41,7 @@
     "react-hook-form": "^7.45.4",
     "react-icons": "^4.10.1",
     "react-query": "^3.39.3",
+    "react-rnd": "^10.4.1",
     "tailwind-merge": "^1.14.0",
     "tailwindcss": "3.3.3",
     "tailwindcss-animate": "^1.0.6",

--- a/src/components/asset-item/asset-item.tsx
+++ b/src/components/asset-item/asset-item.tsx
@@ -14,6 +14,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
+import { cn } from "@/lib/utils";
 
 export interface Asset {
   key: string;
@@ -29,15 +30,16 @@ export const AssetItem: FC<AssetItemProps> = ({ asset }) => {
     assets: { assets, addAsset, removeAsset },
   } = useContext(PosterContext);
 
-  const handleRemoveAsset: MouseEventHandler<HTMLButtonElement> = (event) => {
-    event.stopPropagation();
-
-    // removeAsset(asset);
-  };
+  const isRendered = assets.some((a) => a.key === asset.key);
 
   return (
-    <div className="group relative flex h-full w-full items-center justify-center overflow-hidden bg-white bg-opacity-10">
-      <AssetActions asset={asset} isRendered={assets.includes(asset)} />
+    <div
+      className={cn(
+        "group relative flex h-full w-full items-center justify-center overflow-hidden bg-white bg-opacity-10",
+        `${isRendered && "ring-1 ring-accent"}`
+      )}
+    >
+      <AssetActions asset={asset} isRendered={isRendered} />
       <img
         src={asset.url}
         alt={`Uploaded asset ${asset.key}`}
@@ -60,13 +62,13 @@ const AssetActions: FC<AssetActionsProps> = ({ asset, isRendered }) => {
   const handleAddAsset: MouseEventHandler<HTMLDivElement> = (event) => {
     event.stopPropagation();
 
-    addAsset(asset);
+    addAsset(asset.key);
   };
 
   const handleRemoveAsset: MouseEventHandler<HTMLDivElement> = (event) => {
     event.stopPropagation();
 
-    removeAsset(asset);
+    removeAsset(asset.key);
   };
 
   return (

--- a/src/components/asset-item/asset-item.tsx
+++ b/src/components/asset-item/asset-item.tsx
@@ -1,0 +1,111 @@
+/* eslint-disable @next/next/no-img-element */
+import { FC, MouseEventHandler, useContext } from "react";
+import { IconContext } from "react-icons";
+import { CgRemoveR } from "react-icons/cg";
+import { MdAddBox, MdDelete } from "react-icons/md";
+import { SlOptions } from "react-icons/sl";
+
+import { PosterContext } from "@/context/poster";
+
+import { Button } from "../ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+
+export interface Asset {
+  key: string;
+  url: string;
+}
+
+interface AssetItemProps {
+  asset: Asset;
+}
+
+export const AssetItem: FC<AssetItemProps> = ({ asset }) => {
+  const {
+    assets: { assets, addAsset, removeAsset },
+  } = useContext(PosterContext);
+
+  const handleRemoveAsset: MouseEventHandler<HTMLButtonElement> = (event) => {
+    event.stopPropagation();
+
+    // removeAsset(asset);
+  };
+
+  return (
+    <div className="group relative flex h-full w-full items-center justify-center overflow-hidden bg-white bg-opacity-10">
+      <AssetActions asset={asset} isRendered={assets.includes(asset)} />
+      <img
+        src={asset.url}
+        alt={`Uploaded asset ${asset.key}`}
+        className="object-contain"
+      />
+    </div>
+  );
+};
+
+interface AssetActionsProps {
+  asset: Asset;
+  isRendered?: boolean;
+}
+
+const AssetActions: FC<AssetActionsProps> = ({ asset, isRendered }) => {
+  const {
+    assets: { addAsset, removeAsset },
+  } = useContext(PosterContext);
+
+  const handleAddAsset: MouseEventHandler<HTMLDivElement> = (event) => {
+    event.stopPropagation();
+
+    addAsset(asset);
+  };
+
+  const handleRemoveAsset: MouseEventHandler<HTMLDivElement> = (event) => {
+    event.stopPropagation();
+
+    removeAsset(asset);
+  };
+
+  return (
+    <IconContext.Provider value={{ className: "text-white" }}>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          asChild
+          className="absolute right-2 top-2 bg-black opacity-25 transition-all group-hover:opacity-100"
+        >
+          <Button
+            variant="outline"
+            size="icon"
+            className="inline-flex h-6 w-6 items-center justify-center"
+          >
+            <SlOptions />
+          </Button>
+        </DropdownMenuTrigger>
+        <IconContext.Provider value={{ className: "text-white mr-2 text-lg" }}>
+          <DropdownMenuContent className="bg-black text-white">
+            <DropdownMenuItem
+              onClick={isRendered ? handleRemoveAsset : handleAddAsset}
+            >
+              {isRendered ? <CgRemoveR /> : <MdAddBox />}
+              <span>{isRendered ? "Quitar" : "Agregar"}</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem className="group/delete-item text-red-500 transition-all">
+              <IconContext.Provider
+                value={{
+                  className:
+                    "group-hover/delete-item:text-accent-foreground text-red-500 mr-2 text-lg",
+                }}
+              >
+                <MdDelete />
+                <span>Eliminar</span>
+              </IconContext.Provider>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </IconContext.Provider>
+      </DropdownMenu>
+    </IconContext.Provider>
+  );
+};

--- a/src/components/asset-item/asset-item.tsx
+++ b/src/components/asset-item/asset-item.tsx
@@ -6,6 +6,7 @@ import { MdAddBox, MdDelete } from "react-icons/md";
 import { SlOptions } from "react-icons/sl";
 
 import { PosterContext } from "@/context/poster";
+import { cn } from "@/lib/utils";
 
 import { Button } from "../ui/button";
 import {
@@ -14,7 +15,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
-import { cn } from "@/lib/utils";
 
 export interface Asset {
   key: string;
@@ -36,7 +36,7 @@ export const AssetItem: FC<AssetItemProps> = ({ asset }) => {
     <div
       className={cn(
         "group relative flex h-full w-full items-center justify-center overflow-hidden bg-white bg-opacity-10",
-        `${isRendered && "ring-1 ring-accent"}`
+        `${isRendered && "ring-1 ring-accent"}`,
       )}
     >
       <AssetActions asset={asset} isRendered={isRendered} />

--- a/src/components/post-form/assets-form.tsx
+++ b/src/components/post-form/assets-form.tsx
@@ -1,92 +1,27 @@
-/* eslint-disable @next/next/no-img-element */
-import {
-  ChangeEventHandler,
-  DragEventHandler,
-  FC,
-  MouseEventHandler,
-  useContext,
-  useRef,
-} from "react";
-import { MdDelete } from "react-icons/md";
+import { useContext } from "react";
 import { useQueryClient } from "react-query";
 
 import { PosterContext } from "@/context/poster";
-import { UploadButton, UploadDropzone } from "@/utils/uploadthing";
+import { UploadDropzone } from "@/utils/uploadthing";
 
-import { Button } from "../ui/button";
-import { Input } from "../ui/input";
+import { AssetItem } from "../asset-item/asset-item";
 import { ScrollArea } from "../ui/scroll-area";
-
-export interface Asset {
-  key: string;
-  url: string;
-}
 
 export const AssetsForm = () => {
   const queryClient = useQueryClient();
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const {
-    assetsQuery,
-    assets: { assets, addAsset },
-  } = useContext(PosterContext);
-
-  const handleDrop: DragEventHandler<HTMLDivElement> = (event) => {
-    event.preventDefault();
-
-    const { files } = event.dataTransfer;
-
-    const filesArray = Array.from(files);
-
-    filesArray.forEach((file) => {
-      if (!file.type.startsWith("image/")) return;
-
-      addAsset(file);
-    });
-  };
-
-  const handleDragOver: DragEventHandler<HTMLDivElement> = (event) => {
-    event.preventDefault();
-  };
-
-  const handleClick = () => {
-    fileInputRef.current?.click();
-  };
-
-  const handleInputChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    const { files } = event.target;
-
-    if (files === null) return;
-
-    const filesArray = Array.from(files);
-
-    filesArray.forEach((file) => addAsset(file));
-  };
-
-  console.log(assetsQuery?.data);
+  const { assetsQuery } = useContext(PosterContext);
 
   return (
     <>
       <div className="flex flex-col gap-2">
-        {/* <Label htmlFor="assets">Imágenes</Label> */}
-        <Input
-          ref={fileInputRef}
-          // {...register("picture")}
-          onChange={handleInputChange}
-          id="assets"
-          type="file"
-          accept="image/*"
-          multiple
-          className="hidden"
-        />
         <div className="max-h-60 w-full">
           <UploadDropzone
             endpoint="imageUploader"
-            onClientUploadComplete={(res) =>
+            onClientUploadComplete={(_) =>
               queryClient.invalidateQueries(["assets"])
             }
-            className="ut-button:bg-primary ut-button:px-4 ut-button:mt-2 rounded-sm border-secondary bg-slate-950 p-2"
+            className="rounded-sm border-secondary bg-slate-950 p-2 ut-button:mt-2 ut-button:bg-primary ut-button:px-4 ut-upload-icon:h-12"
             content={{
               label({ ready, isUploading, isDragActive }) {
                 if (isDragActive) return "Suelta tus archivos";
@@ -107,7 +42,8 @@ export const AssetsForm = () => {
           />
         </div>
         <ScrollArea className="rounded-sm border border-primary bg-slate-950">
-          <div className="grid h-60 max-h-60 items-start justify-start gap-2 p-2 md:grid-cols-3 md:grid-rows-2">
+          <div className="grid h-60 items-start justify-start gap-2 p-2 md:grid-cols-3 md:grid-rows-2">
+            {assetsQuery?.isLoading && <p className="text-center col-span-full row-span-full">Loading...</p>}
             {assetsQuery?.data &&
               assetsQuery.data.map((asset, index) => (
                 <AssetItem key={`Asset ${asset.key} ${index}`} asset={asset} />
@@ -116,37 +52,5 @@ export const AssetsForm = () => {
         </ScrollArea>
       </div>
     </>
-  );
-};
-
-interface AssetItemProps {
-  asset: Asset;
-}
-
-const AssetItem: FC<AssetItemProps> = ({ asset }) => {
-  const {
-    assets: { removeAsset },
-  } = useContext(PosterContext);
-
-  const handleRemoveAsset: MouseEventHandler<HTMLButtonElement> = (event) => {
-    event.stopPropagation();
-
-    // removeAsset(asset);
-  };
-
-  return (
-    <div className="group relative w-full bg-white bg-opacity-10">
-      <button
-        onClick={handleRemoveAsset}
-        className="absolute bottom-2 right-2 inline-flex aspect-square w-8 items-center justify-center bg-white bg-opacity-25 text-xl text-secondary transition-all group-hover:bg-opacity-100 group-hover:bg-black rounded-full"
-      >
-        <MdDelete />
-      </button>
-      <img
-        src={asset.url}
-        alt={`Uploaded asset ${asset.key}`}
-        className="aspect-square object-contain"
-      />
-    </div>
   );
 };

--- a/src/components/post-form/assets-form.tsx
+++ b/src/components/post-form/assets-form.tsx
@@ -1,0 +1,126 @@
+/* eslint-disable @next/next/no-img-element */
+import {
+  ChangeEventHandler,
+  DragEventHandler,
+  FC,
+  MouseEventHandler,
+  useContext,
+  useRef,
+} from "react";
+import { MdDelete } from "react-icons/md";
+
+import { PosterContext } from "@/context/poster";
+
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { ScrollArea } from "../ui/scroll-area";
+
+export const AssetsForm = () => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const {
+    assets: { assets, addAsset },
+  } = useContext(PosterContext);
+
+  const handleDrop: DragEventHandler<HTMLDivElement> = (event) => {
+    event.preventDefault();
+
+    const { files } = event.dataTransfer;
+
+    const filesArray = Array.from(files);
+
+    filesArray.forEach((file) => {
+      if (!file.type.startsWith("image/")) return;
+
+      addAsset(file);
+    });
+  };
+
+  const handleDragOver: DragEventHandler<HTMLDivElement> = (event) => {
+    event.preventDefault();
+  };
+
+  const handleClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleInputChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    const { files } = event.target;
+
+    if (files === null) return;
+
+    const filesArray = Array.from(files);
+
+    filesArray.forEach((file) => addAsset(file));
+  };
+
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        {/* <Label htmlFor="assets">Imágenes</Label> */}
+        <Input
+          ref={fileInputRef}
+          // {...register("picture")}
+          onChange={handleInputChange}
+          id="assets"
+          type="file"
+          accept="image/*"
+          multiple
+          className="hidden"
+        />
+        <ScrollArea className="border">
+          <div
+            onClick={handleClick}
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            className="grid h-60 max-h-60 justify-start items-start gap-2 p-2 md:grid-cols-3"
+          >
+            {assets.length < 1 && (
+              <p className="col-span-full row-span-full text-center">
+                Arrastra tus archivos aquí
+              </p>
+            )}
+            {assets.map((asset, index) => (
+              <AssetItem key={`Asset ${asset.name} ${index}`} asset={asset} />
+            ))}
+          </div>
+        </ScrollArea>
+      </div>
+    </>
+  );
+};
+
+interface AssetItemProps {
+  asset: File;
+}
+
+const AssetItem: FC<AssetItemProps> = ({ asset }) => {
+  const {
+    assets: { removeAsset },
+  } = useContext(PosterContext);
+
+  const handleRemoveAsset: MouseEventHandler<HTMLButtonElement> = (event) => {
+    event.stopPropagation();
+
+    removeAsset(asset);
+  };
+
+  return (
+    <div className="group relative w-full">
+      <div className="absolute bottom-2 right-2 h-fit w-fit bg-slate-900 bg-opacity-30 opacity-50 transition-all group-hover:bg-opacity-90 group-hover:opacity-100">
+        <Button
+          size="icon"
+          onClick={handleRemoveAsset}
+          className="w-8 bg-transparent text-xl text-red-600 hover:bg-transparent"
+        >
+          <MdDelete />
+        </Button>
+      </div>
+      <img
+        src={URL.createObjectURL(asset)}
+        alt={asset.name}
+        className="aspect-square object-contain"
+      />
+    </div>
+  );
+};

--- a/src/components/post-form/content-form.tsx
+++ b/src/components/post-form/content-form.tsx
@@ -23,7 +23,6 @@ export interface ContentFormInputs {
   presenters: string;
   location: string;
   time: string;
-  picture: FileList;
 }
 
 export const ContentForm = () => {
@@ -38,12 +37,6 @@ export const ContentForm = () => {
     handleSubmit: submitPresenters,
     reset: resetPresenters,
   } = useForm<Pick<ContentFormInputs, "presenters">>();
-
-  const {
-    register: regPicture,
-    handleSubmit: submitPicture,
-    reset: resetPicture,
-  } = useForm<Pick<ContentFormInputs, "picture">>();
 
   const {
     posterForm,
@@ -62,12 +55,6 @@ export const ContentForm = () => {
   const onSubmitPresenters = (data: Pick<ContentFormInputs, "presenters">) => {
     addPresenter(data.presenters);
     resetPresenters({ presenters: "" });
-  };
-
-  const onSubmitPicture = (data: Pick<ContentFormInputs, "picture">) => {
-    console.log(data);
-    // addPicture(data.picture);
-    // resetPicture({ picture: undefined });
   };
 
   return (

--- a/src/components/post-form/content-form.tsx
+++ b/src/components/post-form/content-form.tsx
@@ -1,0 +1,214 @@
+import { useContext } from "react";
+import { useForm } from "react-hook-form";
+import { MdAdd, MdRemove } from "react-icons/md";
+
+import { PosterContext } from "@/context/poster";
+
+import { Button } from "../ui/button";
+import { DatePicker } from "../ui/date-picker";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+
+export interface ContentFormInputs {
+  event: string;
+  title: string;
+  topics: string;
+  presenters: string;
+  location: string;
+  time: string;
+  picture: FileList;
+}
+
+export const ContentForm = () => {
+  const {
+    register: regContent,
+    handleSubmit: submitContent,
+    reset: resetContent,
+  } = useForm<Pick<ContentFormInputs, "topics">>();
+
+  const {
+    register: regPresenters,
+    handleSubmit: submitPresenters,
+    reset: resetPresenters,
+  } = useForm<Pick<ContentFormInputs, "presenters">>();
+
+  const {
+    register: regPicture,
+    handleSubmit: submitPicture,
+    reset: resetPicture,
+  } = useForm<Pick<ContentFormInputs, "picture">>();
+
+  const {
+    posterForm,
+    topics: { topics, addTopic, removeTopic },
+    presenters: { presenters, addPresenter, removePresenter },
+    date,
+    setTime,
+    setDate,
+  } = useContext(PosterContext);
+
+  const onSubmitContent = (data: Pick<ContentFormInputs, "topics">) => {
+    addTopic(data.topics);
+    resetContent({ topics: "" });
+  };
+
+  const onSubmitPresenters = (data: Pick<ContentFormInputs, "presenters">) => {
+    addPresenter(data.presenters);
+    resetPresenters({ presenters: "" });
+  };
+
+  const onSubmitPicture = (data: Pick<ContentFormInputs, "picture">) => {
+    console.log(data);
+    // addPicture(data.picture);
+    // resetPicture({ picture: undefined });
+  };
+
+  return (
+    <>
+      <div>
+        <Label htmlFor="event">Evento</Label>
+        <Input
+          id="event"
+          {...posterForm?.register("event")}
+          type="text"
+          placeholder="Evento"
+          className="text-muted"
+        />
+      </div>
+      <div>
+        <Label htmlFor="title">Título</Label>
+        <Input
+          id="title"
+          {...posterForm?.register("title")}
+          type="text"
+          placeholder="Título"
+          className="text-muted"
+        />
+      </div>
+      <div>
+        <form onSubmit={submitContent(onSubmitContent)}>
+          <Label htmlFor="content">Contenido</Label>
+          <div className="flex flex-row items-center gap-2">
+            <Input
+              id="content"
+              {...regContent("topics")}
+              type="text"
+              placeholder="Contenido"
+              className="text-muted"
+            />
+            <Button
+              type="submit"
+              size="icon"
+              className="text-lg transition-all hover:bg-primary hover:brightness-110"
+            >
+              <MdAdd />
+            </Button>
+          </div>
+        </form>
+        <ul className="py-2 pl-2">
+          {topics.length < 1 && (
+            <li className="flex flex-row items-center justify-center py-1">
+              No hay temas
+            </li>
+          )}
+          {topics.map((topic, index) => (
+            <li
+              key={`Topic ${topic} ${index}`}
+              className="flex flex-row items-center justify-between gap-2 py-1"
+            >
+              <p>&#62; {topic}</p>
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-6 cursor-pointer bg-transparent text-base text-white"
+                onClick={removeTopic.bind(null, topic)}
+              >
+                <MdRemove />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <form onSubmit={submitPresenters(onSubmitPresenters)}>
+          <Label htmlFor="presenters">Presentadores</Label>
+          <div className="flex flex-row items-center gap-2">
+            <Input
+              id="presenters"
+              {...regPresenters("presenters")}
+              type="text"
+              placeholder="Presentadores"
+              className="text-muted"
+            />
+            <Button
+              type="submit"
+              size="icon"
+              className="text-lg transition-all hover:bg-primary hover:brightness-110"
+            >
+              <MdAdd />
+            </Button>
+          </div>
+        </form>
+        <ul className="py-2 pl-2">
+          {presenters.length < 1 && (
+            <li className="flex flex-row items-center justify-center py-1">
+              No hay presentadores
+            </li>
+          )}
+          {presenters.map((presenter, index) => (
+            <li
+              key={`Presenter ${presenter} ${index}`}
+              className="flex flex-row items-center justify-between gap-2 py-1"
+            >
+              <p>&#62; {presenter}</p>
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-6 cursor-pointer bg-transparent text-base text-white"
+                onClick={removePresenter.bind(null, presenter)}
+              >
+                <MdRemove />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <Label htmlFor="location">Ubicación</Label>
+        <Input
+          id="location"
+          {...posterForm?.register("location")}
+          type="text"
+          placeholder="Ubicación"
+          className="text-muted"
+        />
+      </div>
+      <div>
+        <Label htmlFor="date">Fecha</Label>
+        <DatePicker date={date} setDate={setDate} />
+      </div>
+      <div>
+        <Label htmlFor="time">Hora</Label>
+        <Select onValueChange={setTime}>
+          <SelectTrigger className="w-full text-muted">
+            <SelectValue placeholder="Selecciona la hora" />
+          </SelectTrigger>
+          <SelectContent>
+            {Array.from({ length: 13 }, (_, i) => (
+              <SelectItem key={`Time of day ${i}`} value={`${i + 8}:00`}>
+                {`${i + 8}:00`}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </>
+  );
+};

--- a/src/components/post-form/post-form.tsx
+++ b/src/components/post-form/post-form.tsx
@@ -1,262 +1,91 @@
-import { CalendarIcon } from "lucide-react";
 import Link from "next/link";
-import { FC, useContext } from "react";
-import type { SelectSingleEventHandler } from "react-day-picker";
-import { UseFormRegister, useForm } from "react-hook-form";
+import { FC } from "react";
 import { BiArrowBack } from "react-icons/bi";
-import { MdAdd, MdRemove } from "react-icons/md";
 
-import { PosterContext } from "@/context/poster";
-import { cn } from "@/lib/utils";
-import { formatFullDate } from "@/utils/utils";
-
-import { Button } from "../ui/button";
-import { Calendar } from "../ui/calendar";
-import { Input } from "../ui/input";
-import { Label } from "../ui/label";
-import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "../ui/select";
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "../ui/accordion";
+import { Button } from "../ui/button";
+import { ScrollArea } from "../ui/scroll-area";
 
-export interface PostFormInputs {
-  event: string;
-  title: string;
-  content: string;
-  presenters: string;
-  location: string;
-  time: string;
-}
+import { ContentForm } from "./content-form";
 
 interface Props {
   onDownload: () => void;
 }
 
 export const PostForm: FC<Props> = ({ onDownload }) => {
-  const {
-    register: regContent,
-    handleSubmit: submitContent,
-    reset: resetContent,
-  } = useForm<Pick<PostFormInputs, "content">>();
-
-  const {
-    register: regPresenters,
-    handleSubmit: submitPresenters,
-    reset: resetPresenters,
-  } = useForm<Pick<PostFormInputs, "presenters">>();
-
-  const {
-    posterForm,
-    topics: { topics, addTopic, removeTopic },
-    presenters: { presenters, addPresenter, removePresenter },
-    date,
-    setTime,
-    setDate,
-  } = useContext(PosterContext);
-
-  const onSubmitContent = (data: Pick<PostFormInputs, "content">) => {
-    addTopic(data.content);
-    resetContent({ content: "" });
-  };
-
-  const onSubmitPresenters = (data: Pick<PostFormInputs, "presenters">) => {
-    addPresenter(data.presenters);
-    resetPresenters({ presenters: "" });
-  };
-
   const handleDownload = () => {
     onDownload();
   };
 
   return (
-    <div className="relative h-screen w-full overflow-hidden bg-muted text-white">
-      <div className="relative flex h-full flex-col gap-1 overflow-auto p-2">
-        <div className="flex flex-row items-center gap-2">
-          <Link
-            href="/"
-            className="flex h-8 items-center justify-center rounded-sm border border-white bg-muted px-2 text-lg transition-all hover:bg-primary"
+    <div className="relative col-span-2 h-screen w-full overflow-hidden bg-muted text-white">
+      <ScrollArea className="relative flex h-full flex-col gap-1 overflow-auto">
+        <div className="flex flex-col p-4">
+          <div className="flex flex-row items-center gap-2">
+            <Link
+              href="/"
+              className="flex h-8 items-center justify-center rounded-sm border border-white bg-muted px-2 text-lg transition-all hover:bg-primary"
+            >
+              <BiArrowBack />
+            </Link>
+            <h1 className="text-xl">Edita la plantilla</h1>
+          </div>
+          <Accordion type="single" collapsible>
+            <AccordionItem
+              value="template-props"
+              className="border-b-slate-400"
+            >
+              <AccordionTrigger>Plantilla</AccordionTrigger>
+              <AccordionContent>Let&apos;s go</AccordionContent>
+            </AccordionItem>
+            <AccordionItem value="content-form" className="border-b-slate-400">
+              <AccordionTrigger>Contenido</AccordionTrigger>
+              <AccordionContent>
+                <ContentForm />
+              </AccordionContent>
+            </AccordionItem>
+            <AccordionItem value="assets-form" className="border-b-slate-400">
+              <AccordionTrigger>Recursos</AccordionTrigger>
+              <AccordionContent>Let&apos;s go</AccordionContent>
+            </AccordionItem>
+          </Accordion>
+          <Button
+            type="button"
+            onClick={handleDownload}
+            className="mt-2 w-full transition-all hover:bg-primary hover:brightness-110"
           >
-            <BiArrowBack />
-          </Link>
-          <h1 className="text-xl">Edita el contenido</h1>
+            Descargar
+          </Button>
         </div>
-        <div>
-          <Label htmlFor="event">Evento</Label>
-          <Input
-            id="event"
-            {...posterForm?.register("event")}
-            type="text"
-            placeholder="Evento"
-            className="text-muted"
-          />
-        </div>
-        <div>
-          <Label htmlFor="title">Título</Label>
-          <Input
-            id="title"
-            {...posterForm?.register("title")}
-            type="text"
-            placeholder="Título"
-            className="text-muted"
-          />
-        </div>
-        <div>
-          <form onSubmit={submitContent(onSubmitContent)}>
-            <Label htmlFor="content">Contenido</Label>
-            <div className="flex flex-row items-center gap-2">
-              <Input
-                id="content"
-                {...regContent("content")}
-                type="text"
-                placeholder="Contenido"
-                className="text-muted"
-              />
-              <Button
-                type="submit"
-                className="text-lg transition-all hover:bg-primary hover:brightness-110"
-              >
-                <MdAdd />
-              </Button>
-            </div>
-          </form>
-          <ul className="py-2 pl-2">
-            {topics.length < 1 && (
-              <li className="flex flex-row items-center justify-center py-1">
-                No hay temas
-              </li>
-            )}
-            {topics.map((topic, index) => (
-              <li
-                key={`Topic ${topic} ${index}`}
-                className="flex flex-row items-center justify-between gap-2 py-1"
-              >
-                <p>&#62; {topic}</p>
-                <Button
-                  variant="outline"
-                  className="h-6 cursor-pointer bg-transparent text-lg text-white"
-                  onClick={removeTopic.bind(null, topic)}
-                >
-                  <MdRemove />
-                </Button>
-              </li>
-            ))}
-          </ul>
-        </div>
-        <div>
-          <form onSubmit={submitPresenters(onSubmitPresenters)}>
-            <Label htmlFor="presenters">Presentadores</Label>
-            <div className="flex flex-row items-center gap-2">
-              <Input
-                id="presenters"
-                {...regPresenters("presenters")}
-                type="text"
-                placeholder="Presentadores"
-                className="text-muted"
-              />
-              <Button
-                type="submit"
-                className="text-lg transition-all hover:bg-primary hover:brightness-110"
-              >
-                <MdAdd />
-              </Button>
-            </div>
-          </form>
-          <ul className="py-2 pl-2">
-            {presenters.length < 1 && (
-              <li className="flex flex-row items-center justify-center py-1">
-                No hay presentadores
-              </li>
-            )}
-            {presenters.map((presenter, index) => (
-              <li
-                key={`Presenter ${presenter} ${index}`}
-                className="flex flex-row items-center justify-between gap-2 py-1"
-              >
-                <p>&#62; {presenter}</p>
-                <Button
-                  variant="outline"
-                  className="h-6 cursor-pointer bg-transparent text-lg text-white"
-                  onClick={removePresenter.bind(null, presenter)}
-                >
-                  <MdRemove />
-                </Button>
-              </li>
-            ))}
-          </ul>
-        </div>
-        <div>
-          <Label htmlFor="location">Ubicación</Label>
-          <Input
-            id="location"
-            {...posterForm?.register("location")}
-            type="text"
-            placeholder="Ubicación"
-            className="text-muted"
-          />
-        </div>
-        <div>
-          <Label htmlFor="date">Fecha</Label>
-          <DatePicker date={date} setDate={setDate} />
-        </div>
-        <div>
-          <Label htmlFor="time">Hora</Label>
-          <Select onValueChange={setTime}>
-            <SelectTrigger className="w-full text-muted">
-              <SelectValue placeholder="Selecciona la hora" />
-            </SelectTrigger>
-            <SelectContent>
-              {Array.from({ length: 13 }, (_, i) => (
-                <SelectItem key={i} value={`${i + 8}:00`}>
-                  {`${i + 8}:00`}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <Button
-          type="button"
-          onClick={handleDownload}
-          className="mt-1 w-full transition-all hover:bg-primary hover:brightness-110"
-        >
-          Descargar
-        </Button>
-      </div>
+      </ScrollArea>
     </div>
   );
 };
 
-interface DatePickerProps {
-  date?: Date;
-  setDate: SelectSingleEventHandler;
+{
+  /* <div>
+          <form onSubmit={submitPicture(onSubmitPicture)}>
+            <Label htmlFor="picture">Imagen</Label>
+            <div className="flex flex-row items-center gap-2">
+              <Input
+                {...regPicture("picture")}
+                id="picture"
+                type="file"
+                accept="image/*"
+              />
+              <Button
+                size="icon"
+                type="submit"
+                className="text-lg transition-all hover:bg-primary hover:brightness-110"
+              >
+                <MdAdd />
+              </Button>
+            </div>
+          </form>
+        </div> */
 }
-
-const DatePicker: FC<DatePickerProps> = ({ date, setDate }) => {
-  return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <Button
-          variant={"outline"}
-          className={cn(
-            "w-full justify-start text-left font-normal text-muted hover:bg-primary hover:text-white",
-            !date && "text-muted-foreground",
-          )}
-        >
-          <CalendarIcon className="mr-2 h-4 w-4" />
-          {date ? formatFullDate(date) : <span>Escoge una fecha</span>}
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-auto p-0">
-        <Calendar
-          mode="single"
-          selected={date}
-          onSelect={setDate}
-          initialFocus
-        />
-      </PopoverContent>
-    </Popover>
-  );
-};

--- a/src/components/post-form/post-form.tsx
+++ b/src/components/post-form/post-form.tsx
@@ -12,6 +12,7 @@ import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
 
 import { ContentForm } from "./content-form";
+import { TemplateForm } from "./template-form";
 
 interface Props {
   onDownload: () => void;
@@ -41,7 +42,9 @@ export const PostForm: FC<Props> = ({ onDownload }) => {
               className="border-b-slate-400"
             >
               <AccordionTrigger>Plantilla</AccordionTrigger>
-              <AccordionContent>Let&apos;s go</AccordionContent>
+              <AccordionContent>
+                <TemplateForm />
+              </AccordionContent>
             </AccordionItem>
             <AccordionItem value="content-form" className="border-b-slate-400">
               <AccordionTrigger>Contenido</AccordionTrigger>

--- a/src/components/post-form/post-form.tsx
+++ b/src/components/post-form/post-form.tsx
@@ -51,14 +51,10 @@ export const PostForm: FC<Props> = ({ onDownload }) => {
 
   const {
     posterForm,
-    topics,
-    presenters,
+    topics: { topics, addTopic, removeTopic },
+    presenters: { presenters, addPresenter, removePresenter },
     date,
     setTime,
-    addTopic,
-    removeTopic,
-    addPresenter,
-    removePresenter,
     setDate,
   } = useContext(PosterContext);
 

--- a/src/components/post-form/post-form.tsx
+++ b/src/components/post-form/post-form.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
 
+import { AssetsForm } from "./assets-form";
 import { ContentForm } from "./content-form";
 import { TemplateForm } from "./template-form";
 
@@ -53,8 +54,10 @@ export const PostForm: FC<Props> = ({ onDownload }) => {
               </AccordionContent>
             </AccordionItem>
             <AccordionItem value="assets-form" className="border-b-slate-400">
-              <AccordionTrigger>Recursos</AccordionTrigger>
-              <AccordionContent>Let&apos;s go</AccordionContent>
+              <AccordionTrigger>Recursos gráficos</AccordionTrigger>
+              <AccordionContent>
+                <AssetsForm />
+              </AccordionContent>
             </AccordionItem>
           </Accordion>
           <Button

--- a/src/components/post-form/template-form.tsx
+++ b/src/components/post-form/template-form.tsx
@@ -1,0 +1,1 @@
+export const TemplateForm = () => {};

--- a/src/components/post-form/template-form.tsx
+++ b/src/components/post-form/template-form.tsx
@@ -1,1 +1,20 @@
-export const TemplateForm = () => {};
+import { useContext } from "react";
+
+import { PosterContext } from "@/context/poster";
+
+import { ColorItem } from "../ui/color-item";
+
+export const TemplateForm = () => {
+  const {
+    posterBg: { posterBg },
+  } = useContext(PosterContext);
+
+  return (
+    <div className="flex gap-4 p-4">
+      <ColorItem variant="primary" selected={posterBg === "primary"} />
+      <ColorItem variant="muted" selected={posterBg === "muted"} />
+      {/* <ColorItem variant="white" selected={posterBg === "white"} /> */}
+      {/* <ColorItem variant="gray" selected={posterBg === "gray"} /> */}
+    </div>
+  );
+};

--- a/src/components/post-generator/post-generator.tsx
+++ b/src/components/post-generator/post-generator.tsx
@@ -1,10 +1,7 @@
 import { toPng } from "html-to-image";
-import { useRef, useState } from "react";
-import { useForm } from "react-hook-form";
+import { useRef } from "react";
 
-import { PosterContext } from "@/context/poster";
-
-import { PostForm, PostFormInputs } from "../post-form/post-form";
+import { PostForm } from "../post-form/post-form";
 import { PostViewer } from "../post-viewer/post-viewer";
 
 export const PostGenerator = () => {
@@ -26,7 +23,7 @@ export const PostGenerator = () => {
   };
 
   return (
-    <section className="grid w-full grid-cols-1 gap-1 md:grid-cols-3">
+    <section className="grid w-full grid-cols-1 grid-rows-2 md:grid-cols-5 md:grid-rows-1">
       <PostViewer postRef={posterRef} />
       <PostForm onDownload={handlePostDownload} />
     </section>

--- a/src/components/post-viewer/post-viewer.tsx
+++ b/src/components/post-viewer/post-viewer.tsx
@@ -1,6 +1,8 @@
+/* eslint-disable @next/next/no-img-element */
 import Image from "next/image";
 import { FC, RefObject, useContext, useRef, useState } from "react";
 import { IoLocationSharp, IoCalendarClear, IoTimeSharp } from "react-icons/io5";
+import { Rnd } from "react-rnd";
 
 import { PosterContext } from "@/context/poster";
 import { cn } from "@/lib/utils";
@@ -24,6 +26,7 @@ export const PostViewer: FC<Props> = ({ postRef }) => {
     posterBg: { posterBg },
     topics: { topics },
     presenters: { presenters },
+    assets: { assets },
     date,
     time,
     posterForm,
@@ -71,6 +74,19 @@ export const PostViewer: FC<Props> = ({ postRef }) => {
                 contextText,
               )}
             >
+              {assets.map((asset, index) => (
+                <Rnd
+                  key={`${asset.key} ${index}`}
+                  className="border-none p-4 hover:border hover:border-solid"
+                >
+                  <img
+                    src={asset.url}
+                    alt={asset.url}
+                    draggable="false"
+                    className="aspect-square w-full"
+                  />
+                </Rnd>
+              ))}
               <span className="absolute left-8 top-8 flex flex-row gap-2 text-5xl">
                 <h1>CSI PRO</h1>
                 {posterForm && posterForm?.watch("event")?.length > 0 && (
@@ -96,7 +112,7 @@ export const PostViewer: FC<Props> = ({ postRef }) => {
                   {topics.map((topic, index) => (
                     <li
                       key={`Topic ${topic} ${index}`}
-                      className="flex flex-row"
+                      className="flex flex-row py-1"
                     >
                       <p>&#62; {topic}</p>
                     </li>
@@ -109,7 +125,7 @@ export const PostViewer: FC<Props> = ({ postRef }) => {
                   {presenters.map((presenter, index) => (
                     <li
                       key={`Presenter ${presenter} ${index}`}
-                      className="flex flex-row"
+                      className="flex flex-row py-1"
                     >
                       <p>&#62; {presenter}</p>
                     </li>
@@ -119,7 +135,7 @@ export const PostViewer: FC<Props> = ({ postRef }) => {
               <div className="w-1/2"></div>
               <div className="col-span-2 flex flex-col gap-2 pl-2">
                 <h1>Ubicación y fecha</h1>
-                <div className="gap-1pl-5 flex flex-col">
+                <div className="flex flex-col gap-1">
                   <span className="flex items-center gap-2">
                     <IoLocationSharp />
                     <p>{posterForm?.watch("location")}</p>

--- a/src/components/post-viewer/post-viewer.tsx
+++ b/src/components/post-viewer/post-viewer.tsx
@@ -19,8 +19,13 @@ interface Props {
 
 export const PostViewer: FC<Props> = ({ postRef }) => {
   const viewerRef = useRef<HTMLDivElement>(null);
-  const { topics, presenters, date, time, posterForm } =
-    useContext(PosterContext);
+  const {
+    topics: { topics },
+    presenters: { presenters },
+    date,
+    time,
+    posterForm,
+  } = useContext(PosterContext);
 
   const [zoom, setZoom] = useState(1);
 

--- a/src/components/post-viewer/post-viewer.tsx
+++ b/src/components/post-viewer/post-viewer.tsx
@@ -3,9 +3,11 @@ import { FC, RefObject, useContext, useRef, useState } from "react";
 import { IoLocationSharp, IoCalendarClear, IoTimeSharp } from "react-icons/io5";
 
 import { PosterContext } from "@/context/poster";
+import { cn } from "@/lib/utils";
 import { formatFullTemplateDate } from "@/utils/utils";
 
 import { SocialMedia } from "../social-media/social-media";
+import { colorItemVariants } from "../ui/color-item";
 import { NameEmphasis } from "../ui/name-emphasis";
 import { ScrollArea } from "../ui/scroll-area";
 
@@ -19,6 +21,7 @@ interface Props {
 export const PostViewer: FC<Props> = ({ postRef }) => {
   const viewerRef = useRef<HTMLDivElement>(null);
   const {
+    posterBg: { posterBg },
     topics: { topics },
     presenters: { presenters },
     date,
@@ -44,6 +47,8 @@ export const PostViewer: FC<Props> = ({ postRef }) => {
     setZoom(1);
   };
 
+  const { bg: contextBg, text: contextText } = colorItemVariants[posterBg];
+
   return (
     <div className="relative col-span-3 max-h-96 max-w-full bg-slate-800 text-white md:max-h-screen">
       <ViewerControls
@@ -60,7 +65,11 @@ export const PostViewer: FC<Props> = ({ postRef }) => {
           >
             <div
               ref={postRef}
-              className="relative grid aspect-square w-[1080px] grid-cols-3 grid-rows-4 gap-2 bg-primary px-8 py-24 text-3xl"
+              className={cn(
+                "relative grid aspect-square w-[1080px] grid-cols-3 grid-rows-4 gap-2 px-8 py-24 text-3xl transition-all",
+                contextBg,
+                contextText,
+              )}
             >
               <span className="absolute left-8 top-8 flex flex-row gap-2 text-5xl">
                 <h1>CSI PRO</h1>
@@ -71,7 +80,12 @@ export const PostViewer: FC<Props> = ({ postRef }) => {
               <div className="col-span-full pl-2">
                 <div className="flex h-full flex-col items-center justify-center">
                   {posterForm && posterForm?.watch("title")?.length > 0 && (
-                    <h1 className="bg-white px-4 py-2 text-center text-7xl font-bold text-primary">
+                    <h1
+                      className={cn(
+                        "bg-white px-4 py-2 text-center text-7xl font-bold",
+                        colorItemVariants[posterBg].nameEmphasis,
+                      )}
+                    >
                       {posterForm?.watch("title")}
                     </h1>
                   )}

--- a/src/components/post-viewer/post-viewer.tsx
+++ b/src/components/post-viewer/post-viewer.tsx
@@ -17,6 +17,7 @@ interface Props {
   postRef: RefObject<HTMLDivElement>;
 }
 
+// TODO: Fix image download on mobile
 export const PostViewer: FC<Props> = ({ postRef }) => {
   const viewerRef = useRef<HTMLDivElement>(null);
   const {
@@ -46,7 +47,7 @@ export const PostViewer: FC<Props> = ({ postRef }) => {
   };
 
   return (
-    <div className="relative col-span-2 flex max-w-full bg-slate-800 text-white md:max-h-screen">
+    <div className="relative max-h-96 col-span-2 max-w-full bg-slate-800 text-white md:max-h-screen">
       <IconContext.Provider value={{ className: "text-white" }}>
         <div className="absolute right-5 top-5 z-10 flex flex-col items-center gap-2 bg-slate-900 px-2 text-xs opacity-30 transition-opacity hover:opacity-100">
           <button
@@ -72,7 +73,7 @@ export const PostViewer: FC<Props> = ({ postRef }) => {
       </IconContext.Provider>
       <div
         ref={viewerRef}
-        className="flex max-h-full max-w-full overflow-scroll p-1"
+        className="flex h-full md:w-full overflow-scroll p-1 md:h-full"
       >
         <div
           className="transition-transform"

--- a/src/components/post-viewer/post-viewer.tsx
+++ b/src/components/post-viewer/post-viewer.tsx
@@ -77,7 +77,8 @@ export const PostViewer: FC<Props> = ({ postRef }) => {
               {assets.map((asset, index) => (
                 <Rnd
                   key={`${asset.key} ${index}`}
-                  className="border-none p-4 hover:border hover:border-solid"
+                  className="absolute z-10 p-4 hover:ring hover:ring-accent"
+                  lockAspectRatio={true}
                 >
                   <img
                     src={asset.url}

--- a/src/components/post-viewer/post-viewer.tsx
+++ b/src/components/post-viewer/post-viewer.tsx
@@ -1,17 +1,15 @@
 import Image from "next/image";
 import { FC, RefObject, useContext, useRef, useState } from "react";
-import { UseFormWatch } from "react-hook-form";
-import { IconContext } from "react-icons";
-import { GrUndo } from "react-icons/gr";
 import { IoLocationSharp, IoCalendarClear, IoTimeSharp } from "react-icons/io5";
-import { MdAdd, MdFitScreen, MdRemove } from "react-icons/md";
 
 import { PosterContext } from "@/context/poster";
 import { formatFullTemplateDate } from "@/utils/utils";
 
-import { PostFormInputs } from "../post-form/post-form";
 import { SocialMedia } from "../social-media/social-media";
 import { NameEmphasis } from "../ui/name-emphasis";
+import { ScrollArea } from "../ui/scroll-area";
+
+import { ViewerControls } from "./viewer-controls";
 
 interface Props {
   postRef: RefObject<HTMLDivElement>;
@@ -47,118 +45,103 @@ export const PostViewer: FC<Props> = ({ postRef }) => {
   };
 
   return (
-    <div className="relative max-h-96 col-span-2 max-w-full bg-slate-800 text-white md:max-h-screen">
-      <IconContext.Provider value={{ className: "text-white" }}>
-        <div className="absolute right-5 top-5 z-10 flex flex-col items-center gap-2 bg-slate-900 px-2 text-xs opacity-30 transition-opacity hover:opacity-100">
-          <button
-            className="cursor-pointer p-1 text-base"
-            onClick={handleZoom.bind(null, 0.05)}
-          >
-            <MdAdd />
-          </button>
-          <p className="text-sm">{zoom.toFixed(2)}</p>
-          <button
-            className="cursor-pointer p-1"
-            onClick={handleZoom.bind(null, -0.05)}
-          >
-            <MdRemove />
-          </button>
-          <button className="py-1 text-base" onClick={fitToViewer}>
-            <MdFitScreen />
-          </button>
-          <button className="py-1 text-base" onClick={resetZoom}>
-            <GrUndo />
-          </button>
-        </div>
-      </IconContext.Provider>
-      <div
-        ref={viewerRef}
-        className="flex h-full md:w-full overflow-scroll p-1 md:h-full"
-      >
-        <div
-          className="transition-transform"
-          style={{ transform: `scale(${zoom})`, transformOrigin: "top left" }}
-        >
+    <div className="relative col-span-3 max-h-96 max-w-full bg-slate-800 text-white md:max-h-screen">
+      <ViewerControls
+        zoom={zoom}
+        handleZoom={handleZoom}
+        fitToViewer={fitToViewer}
+        resetZoom={resetZoom}
+      />
+      <div ref={viewerRef} className="flex h-full p-1 md:h-full md:w-full">
+        <ScrollArea>
           <div
-            ref={postRef}
-            className="relative grid aspect-square w-[1080px] grid-cols-3 grid-rows-4 gap-2 bg-primary px-8 py-24 text-3xl"
+            className="transition-transform"
+            style={{ transform: `scale(${zoom})`, transformOrigin: "top left" }}
           >
-            <span className="absolute left-8 top-8 flex flex-row gap-2 text-5xl">
-              <h1>CSI PRO</h1>
-              {posterForm && posterForm?.watch("event")?.length > 0 && (
-                <NameEmphasis>{posterForm?.watch("event")}</NameEmphasis>
-              )}
-            </span>
-            <div className="col-span-full pl-2">
-              <div className="flex h-full flex-col items-center justify-center">
-                {posterForm && posterForm?.watch("title")?.length > 0 && (
-                  <h1 className="bg-white px-4 py-2 text-center text-7xl font-bold text-primary">
-                    {posterForm?.watch("title")}
-                  </h1>
+            <div
+              ref={postRef}
+              className="relative grid aspect-square w-[1080px] grid-cols-3 grid-rows-4 gap-2 bg-primary px-8 py-24 text-3xl"
+            >
+              <span className="absolute left-8 top-8 flex flex-row gap-2 text-5xl">
+                <h1>CSI PRO</h1>
+                {posterForm && posterForm?.watch("event")?.length > 0 && (
+                  <NameEmphasis>{posterForm?.watch("event")}</NameEmphasis>
                 )}
+              </span>
+              <div className="col-span-full pl-2">
+                <div className="flex h-full flex-col items-center justify-center">
+                  {posterForm && posterForm?.watch("title")?.length > 0 && (
+                    <h1 className="bg-white px-4 py-2 text-center text-7xl font-bold text-primary">
+                      {posterForm?.watch("title")}
+                    </h1>
+                  )}
+                </div>
               </div>
-            </div>
-            <div className="col-span-2 pl-2">
-              <ul className="ml-px border-l-4 border-white pl-5">
-                {topics.map((topic, index) => (
-                  <li key={`Topic ${topic} ${index}`} className="flex flex-row">
-                    <p>&#62; {topic}</p>
-                  </li>
-                ))}
-              </ul>
-            </div>
-            <div className="col-span-2 flex flex-col gap-2 pl-2">
-              <h2>Presentado por:</h2>
-              <ul className="ml-px">
-                {presenters.map((presenter, index) => (
-                  <li
-                    key={`Presenter ${presenter} ${index}`}
-                    className="flex flex-row"
-                  >
-                    <p>&#62; {presenter}</p>
-                  </li>
-                ))}
-              </ul>
-            </div>
-            <div className="w-1/2"></div>
-            <div className="col-span-2 flex flex-col gap-2 pl-2">
-              <h1>Ubicación y fecha</h1>
-              <div className="gap-1pl-5 flex flex-col">
-                <span className="flex items-center gap-2">
-                  <IoLocationSharp />
-                  <p>{posterForm?.watch("location")}</p>
-                </span>
-                {date && (
-                  <span className="flex flex-row items-center gap-2">
-                    <IoCalendarClear />
-                    <>
-                      <p>{formatFullTemplateDate(date)}</p>
-                    </>
+              <div className="col-span-2 pl-2">
+                <ul className="ml-px border-l-4 border-white pl-5">
+                  {topics.map((topic, index) => (
+                    <li
+                      key={`Topic ${topic} ${index}`}
+                      className="flex flex-row"
+                    >
+                      <p>&#62; {topic}</p>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div className="col-span-2 flex flex-col gap-2 pl-2">
+                <h2>Presentado por:</h2>
+                <ul className="ml-px">
+                  {presenters.map((presenter, index) => (
+                    <li
+                      key={`Presenter ${presenter} ${index}`}
+                      className="flex flex-row"
+                    >
+                      <p>&#62; {presenter}</p>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div className="w-1/2"></div>
+              <div className="col-span-2 flex flex-col gap-2 pl-2">
+                <h1>Ubicación y fecha</h1>
+                <div className="gap-1pl-5 flex flex-col">
+                  <span className="flex items-center gap-2">
+                    <IoLocationSharp />
+                    <p>{posterForm?.watch("location")}</p>
                   </span>
-                )}
-                <span className="flex flex-row items-center gap-2">
-                  <IoTimeSharp />
-                  {time && time.length > 0 && <p>{time} hrs</p>}
-                </span>
+                  {date && (
+                    <span className="flex flex-row items-center gap-2">
+                      <IoCalendarClear />
+                      <>
+                        <p>{formatFullTemplateDate(date)}</p>
+                      </>
+                    </span>
+                  )}
+                  <span className="flex flex-row items-center gap-2">
+                    <IoTimeSharp />
+                    {time && time.length > 0 && <p>{time} hrs</p>}
+                  </span>
+                </div>
               </div>
+              <div className=""></div>
+              <div className="absolute bottom-8 left-8 flex w-3/4 flex-row gap-4">
+                <SocialMedia variant="instagram">@csipro.dev</SocialMedia>
+                <SocialMedia variant="github">/csipro</SocialMedia>
+                <SocialMedia variant="twitter">@csipro_dev</SocialMedia>
+                <SocialMedia variant="linkedin">/csi-pro</SocialMedia>
+                <SocialMedia variant="facebook">/csipro.dev</SocialMedia>
+              </div>
+              <Image
+                src="/assets/csipro.svg"
+                alt="CSI PRO icon"
+                width={120}
+                height={120}
+                className="absolute bottom-8 right-8"
+              />
             </div>
-            <div className=""></div>
-            <div className="absolute bottom-8 left-8 flex w-3/4 flex-row gap-4">
-              <SocialMedia variant="instagram">@csipro.dev</SocialMedia>
-              <SocialMedia variant="github">/csipro</SocialMedia>
-              <SocialMedia variant="twitter">@csipro_dev</SocialMedia>
-              <SocialMedia variant="linkedin">/csi-pro</SocialMedia>
-              <SocialMedia variant="facebook">/csipro.dev</SocialMedia>
-            </div>
-            <Image
-              src="/assets/csipro.svg"
-              alt="CSI PRO icon"
-              width={120}
-              height={120}
-              className="absolute bottom-8 right-8"
-            />
           </div>
-        </div>
+        </ScrollArea>
       </div>
     </div>
   );

--- a/src/components/post-viewer/viewer-controls.tsx
+++ b/src/components/post-viewer/viewer-controls.tsx
@@ -1,0 +1,79 @@
+import { FC } from "react";
+import { IconContext } from "react-icons";
+import { GrUndo } from "react-icons/gr";
+import { MdAdd, MdFitScreen, MdRemove } from "react-icons/md";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../ui/tooltip";
+
+interface Props {
+  zoom: number;
+  handleZoom: (zoom: number) => void;
+  fitToViewer: () => void;
+  resetZoom: () => void;
+}
+
+export const ViewerControls: FC<Props> = ({
+  zoom,
+  handleZoom,
+  fitToViewer,
+  resetZoom,
+}) => (
+  <IconContext.Provider value={{ className: "text-white" }}>
+    <TooltipProvider>
+      <div className="absolute right-5 top-5 z-10 flex flex-col items-center gap-2 bg-slate-900 px-2 text-xs opacity-30 transition-opacity hover:opacity-100">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              className="cursor-pointer p-1 text-base"
+              onClick={handleZoom.bind(null, 0.05)}
+            >
+              <MdAdd />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left" sideOffset={16}>
+            <p>Acercar</p>
+          </TooltipContent>
+        </Tooltip>
+        <p className="text-sm">{zoom.toFixed(2)}</p>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              className="cursor-pointer p-1"
+              onClick={handleZoom.bind(null, -0.05)}
+            >
+              <MdRemove />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left" sideOffset={16}>
+            <p>Alejar</p>
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button className="py-1 text-base" onClick={fitToViewer}>
+              <MdFitScreen />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left" sideOffset={16}>
+            <p>Ajustar</p>
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button className="py-1 text-base" onClick={resetZoom}>
+              <GrUndo />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left" sideOffset={16}>
+            <p>Restablecer</p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </TooltipProvider>
+  </IconContext.Provider>
+);

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,58 @@
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDown } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Accordion = AccordionPrimitive.Root;
+
+const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn("border-b", className)}
+    {...props}
+  />
+));
+AccordionItem.displayName = "AccordionItem";
+
+const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+));
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
+
+const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className={cn(
+      "overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down",
+      className,
+    )}
+    {...props}
+  >
+    <div className="pb-4 pt-0">{children}</div>
+  </AccordionPrimitive.Content>
+));
+AccordionContent.displayName = AccordionPrimitive.Content.displayName;
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/src/components/ui/color-item.tsx
+++ b/src/components/ui/color-item.tsx
@@ -1,0 +1,47 @@
+import { FC, useContext } from "react";
+
+import { PosterContext } from "@/context/poster";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  variant: "primary" | "muted";
+  selected?: boolean;
+}
+
+interface VariantValue {
+  bg: string;
+  text: string;
+  nameEmphasis: string;
+}
+
+export const colorItemVariants: Record<Props["variant"], VariantValue> = {
+  primary: {
+    bg: "bg-primary",
+    text: "text-primary-foreground",
+    nameEmphasis: "text-primary",
+  },
+  muted: {
+    bg: "bg-muted",
+    text: "text-primary-foreground",
+    nameEmphasis: "text-muted",
+  },
+  // white: "bg-white text-muted",
+  // gray: "bg-gray-400 text-muted",
+};
+
+export const ColorItem: FC<Props> = ({ variant, selected }) => {
+  const {
+    posterBg: { setPosterBg },
+  } = useContext(PosterContext);
+
+  return (
+    <div
+      onClick={setPosterBg.bind(null, variant)}
+      className={cn(
+        "aspect-square w-6 cursor-pointer rounded-full ring-2 ring-gray-400 transition-all hover:ring-secondary",
+        colorItemVariants[variant].bg,
+        selected && "ring-2 ring-accent",
+      )}
+    />
+  );
+};

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -1,0 +1,198 @@
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const ContextMenu = ContextMenuPrimitive.Root;
+
+const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
+
+const ContextMenuGroup = ContextMenuPrimitive.Group;
+
+const ContextMenuPortal = ContextMenuPrimitive.Portal;
+
+const ContextMenuSub = ContextMenuPrimitive.Sub;
+
+const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup;
+
+const ContextMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <ContextMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </ContextMenuPrimitive.SubTrigger>
+));
+ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
+
+const ContextMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    {...props}
+  />
+));
+ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
+
+const ContextMenuContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Content
+      ref={ref}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+));
+ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
+
+const ContextMenuItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
+
+const ContextMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <ContextMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.CheckboxItem>
+));
+ContextMenuCheckboxItem.displayName =
+  ContextMenuPrimitive.CheckboxItem.displayName;
+
+const ContextMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <ContextMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.RadioItem>
+));
+ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName;
+
+const ContextMenuLabel = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold text-foreground",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+ContextMenuLabel.displayName = ContextMenuPrimitive.Label.displayName;
+
+const ContextMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    {...props}
+  />
+));
+ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName;
+
+const ContextMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+ContextMenuShortcut.displayName = "ContextMenuShortcut";
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+};

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -1,0 +1,42 @@
+import { CalendarIcon } from "lucide-react";
+import { FC } from "react";
+import type { SelectSingleEventHandler } from "react-day-picker";
+
+import { cn } from "@/lib/utils";
+import { formatFullDate } from "@/utils/utils";
+
+import { Button } from "./button";
+import { Calendar } from "./calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+
+interface DatePickerProps {
+  date?: Date;
+  setDate: SelectSingleEventHandler;
+}
+
+export const DatePicker: FC<DatePickerProps> = ({ date, setDate }) => {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant={"outline"}
+          className={cn(
+            "w-full justify-start text-left font-normal text-muted hover:bg-primary hover:text-white",
+            !date && "text-muted-foreground",
+          )}
+        >
+          <CalendarIcon className="mr-2 h-4 w-4" />
+          {date ? formatFullDate(date) : <span>Escoge una fecha</span>}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0">
+        <Calendar
+          mode="single"
+          selected={date}
+          onSelect={setDate}
+          initialFocus
+        />
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,198 @@
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName;
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName;
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      {...props}
+    />
+  );
+};
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+};

--- a/src/components/ui/name-emphasis.tsx
+++ b/src/components/ui/name-emphasis.tsx
@@ -1,4 +1,9 @@
-import { FC, ReactNode } from "react";
+import { FC, ReactNode, useContext } from "react";
+
+import { PosterContext } from "@/context/poster";
+import { cn } from "@/lib/utils";
+
+import { colorItemVariants } from "./color-item";
 
 interface Props {
   children: ReactNode;
@@ -6,7 +11,9 @@ interface Props {
 
 export const FullNameEmphasis: FC<Props> = ({ children }) => {
   return (
-    <span className={`flex flex-row gap-2 text-xl md:text-5xl whitespace-nowrap`}>
+    <span
+      className={`flex flex-row gap-2 whitespace-nowrap text-xl md:text-5xl`}
+    >
       <h1>CSI PRO</h1>
       <NameEmphasis>{children}</NameEmphasis>
     </span>
@@ -14,8 +21,17 @@ export const FullNameEmphasis: FC<Props> = ({ children }) => {
 };
 
 export const NameEmphasis: FC<Props> = ({ children }) => {
+  const {
+    posterBg: { posterBg },
+  } = useContext(PosterContext);
+
   return (
-    <h1 className="bg-white px-2 font-bold uppercase tracking-wider text-primary">
+    <h1
+      className={cn(
+        "bg-white px-2 font-bold uppercase tracking-wider",
+        colorItemVariants[posterBg].nameEmphasis,
+      )}
+    >
       {children}
     </h1>
   );

--- a/src/components/ui/name-emphasis.tsx
+++ b/src/components/ui/name-emphasis.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export const FullNameEmphasis: FC<Props> = ({ children }) => {
   return (
-    <span className="flex flex-row gap-2 text-5xl">
+    <span className={`flex flex-row gap-2 text-xl md:text-5xl whitespace-nowrap`}>
       <h1>CSI PRO</h1>
       <NameEmphasis>{children}</NameEmphasis>
     </span>
@@ -15,7 +15,7 @@ export const FullNameEmphasis: FC<Props> = ({ children }) => {
 
 export const NameEmphasis: FC<Props> = ({ children }) => {
   return (
-    <h1 className="text-primary bg-white px-2 font-bold uppercase tracking-wider">
+    <h1 className="bg-white px-2 font-bold uppercase tracking-wider text-primary">
       {children}
     </h1>
   );

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,47 @@
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollBar orientation="horizontal" />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+));
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 border-t border-t-transparent p-[1px]",
+      className,
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+));
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
+
+export { ScrollArea, ScrollBar };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,28 @@
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    {...props}
+  />
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/context/poster.tsx
+++ b/src/context/poster.tsx
@@ -9,10 +9,10 @@ import {
 import type { SelectSingleEventHandler } from "react-day-picker";
 import { UseFormReturn, useForm } from "react-hook-form";
 
-import { PostFormInputs } from "@/components/post-form/post-form";
+import type { ContentFormInputs } from "@/components/post-form/content-form";
 
 interface PosterContextProps {
-  posterForm?: UseFormReturn<PostFormInputs, undefined, any>;
+  posterForm?: UseFormReturn<ContentFormInputs, undefined, any>;
   topics: {
     topics: string[];
     addTopic: (topic: string) => void;
@@ -68,7 +68,7 @@ export const PosterContextProvider: FC<{ children: ReactNode }> = ({
   const [date, setDate] = useState<Date>();
   const [time, setTime] = useState<string>();
 
-  const posterForm = useForm<PostFormInputs>();
+  const posterForm = useForm<ContentFormInputs>();
 
   const addTopic = (topic: string) => {
     if (!topic) return;

--- a/src/context/poster.tsx
+++ b/src/context/poster.tsx
@@ -1,18 +1,16 @@
-import {
-  FC,
-  ReactNode,
-  RefObject,
-  createContext,
-  useRef,
-  useState,
-} from "react";
+import { FC, ReactNode, createContext, useState } from "react";
 import type { SelectSingleEventHandler } from "react-day-picker";
 import { UseFormReturn, useForm } from "react-hook-form";
 
 import type { ContentFormInputs } from "@/components/post-form/content-form";
+import { colorItemVariants } from "@/components/ui/color-item";
 
 interface PosterContextProps {
   posterForm?: UseFormReturn<ContentFormInputs, undefined, any>;
+  posterBg: {
+    posterBg: keyof typeof colorItemVariants;
+    setPosterBg: (color: keyof typeof colorItemVariants) => void;
+  };
   topics: {
     topics: string[];
     addTopic: (topic: string) => void;
@@ -38,23 +36,24 @@ interface PosterContextProps {
 }
 
 export const PosterContext = createContext<PosterContextProps>({
+  posterBg: { posterBg: "primary", setPosterBg: (color) => {} },
   topics: {
     topics: [],
-    addTopic: (topic: string) => {},
-    removeTopic: (topic: string) => {},
-    setTopics: (topics: string[]) => {},
+    addTopic: (topic) => {},
+    removeTopic: (topic) => {},
+    setTopics: (topics) => {},
   },
   presenters: {
     presenters: [],
-    addPresenter: (presenter: string) => {},
-    removePresenter: (presenter: string) => {},
-    setPresenters: (presenters: string[]) => {},
+    addPresenter: (presenter) => {},
+    removePresenter: (presenter) => {},
+    setPresenters: (presenters) => {},
   },
   pictures: {
     pictures: [],
-    addPicture: (picture: string) => {},
-    removePicture: (picture: string) => {},
-    setPictures: (pictures: string[]) => {},
+    addPicture: (picture) => {},
+    removePicture: (picture) => {},
+    setPictures: (pictures) => {},
   },
   date: new Date(),
   setDate: () => {},
@@ -63,6 +62,8 @@ export const PosterContext = createContext<PosterContextProps>({
 export const PosterContextProvider: FC<{ children: ReactNode }> = ({
   children,
 }) => {
+  const [posterBg, setPosterBg] =
+    useState<keyof typeof colorItemVariants>("primary");
   const [topics, setTopics] = useState<string[]>([]);
   const [presenters, setPresenters] = useState<string[]>([]);
   const [date, setDate] = useState<Date>();
@@ -94,6 +95,10 @@ export const PosterContextProvider: FC<{ children: ReactNode }> = ({
 
   const providerValue = {
     posterForm,
+    posterBg: {
+      posterBg,
+      setPosterBg,
+    },
     topics: {
       topics,
       addTopic,

--- a/src/context/poster.tsx
+++ b/src/context/poster.tsx
@@ -1,12 +1,15 @@
 import { FC, ReactNode, createContext, useState } from "react";
 import type { SelectSingleEventHandler } from "react-day-picker";
 import { UseFormReturn, useForm } from "react-hook-form";
+import { useQuery, type UseQueryResult } from "react-query";
 
+import { Asset } from "@/components/post-form/assets-form";
 import type { ContentFormInputs } from "@/components/post-form/content-form";
 import { colorItemVariants } from "@/components/ui/color-item";
 
 interface PosterContextProps {
   posterForm?: UseFormReturn<ContentFormInputs, undefined, any>;
+  assetsQuery?: UseQueryResult<Asset[], unknown>;
   posterBg: {
     posterBg: keyof typeof colorItemVariants;
     setPosterBg: (color: keyof typeof colorItemVariants) => void;
@@ -59,9 +62,19 @@ export const PosterContext = createContext<PosterContextProps>({
   setDate: () => {},
 });
 
+const getAssets = async () => {
+  const res = await fetch("/api/images");
+
+  const data = (await res.json()) as Asset[];
+
+  return data;
+};
+
 export const PosterContextProvider: FC<{ children: ReactNode }> = ({
   children,
 }) => {
+  const assetsQuery = useQuery({ queryKey: ["assets"], queryFn: getAssets });
+
   const [posterBg, setPosterBg] =
     useState<keyof typeof colorItemVariants>("primary");
   const [topics, setTopics] = useState<string[]>([]);
@@ -105,6 +118,7 @@ export const PosterContextProvider: FC<{ children: ReactNode }> = ({
 
   const providerValue = {
     posterForm,
+    assetsQuery,
     posterBg: {
       posterBg,
       setPosterBg,

--- a/src/context/poster.tsx
+++ b/src/context/poster.tsx
@@ -3,7 +3,7 @@ import type { SelectSingleEventHandler } from "react-day-picker";
 import { UseFormReturn, useForm } from "react-hook-form";
 import { useQuery, type UseQueryResult } from "react-query";
 
-import { Asset } from "@/components/post-form/assets-form";
+import { Asset } from "@/components/asset-item/asset-item";
 import type { ContentFormInputs } from "@/components/post-form/content-form";
 import { colorItemVariants } from "@/components/ui/color-item";
 
@@ -27,10 +27,10 @@ interface PosterContextProps {
     setPresenters: (presenters: string[]) => void;
   };
   assets: {
-    assets: File[];
-    addAsset: (asset: File) => void;
-    removeAsset: (asset: File) => void;
-    setAssets: (assets: File[]) => void;
+    assets: Asset[];
+    addAsset: (asset: Asset) => void;
+    removeAsset: (asset: Asset) => void;
+    setAssets: (assets: Asset[]) => void;
   };
   date?: Date;
   time?: string;
@@ -79,7 +79,7 @@ export const PosterContextProvider: FC<{ children: ReactNode }> = ({
     useState<keyof typeof colorItemVariants>("primary");
   const [topics, setTopics] = useState<string[]>([]);
   const [presenters, setPresenters] = useState<string[]>([]);
-  const [assets, setAssets] = useState<File[]>([]);
+  const [assets, setAssets] = useState<Asset[]>([]);
 
   const [date, setDate] = useState<Date>();
   const [time, setTime] = useState<string>();
@@ -108,11 +108,11 @@ export const PosterContextProvider: FC<{ children: ReactNode }> = ({
     );
   };
 
-  const addAsset = (asset: File) => {
+  const addAsset = (asset: Asset) => {
     setAssets((prevAssets) => [...prevAssets, asset]);
   };
 
-  const removeAsset = (asset: File) => {
+  const removeAsset = (asset: Asset) => {
     setAssets((prevAssets) => prevAssets.filter((a) => a !== asset));
   };
 

--- a/src/context/poster.tsx
+++ b/src/context/poster.tsx
@@ -23,11 +23,11 @@ interface PosterContextProps {
     removePresenter: (presenter: string) => void;
     setPresenters: (presenters: string[]) => void;
   };
-  pictures?: {
-    pictures: string[];
-    addPicture?: (picture: string) => void;
-    removePicture?: (picture: string) => void;
-    setPictures?: (pictures: string[]) => void;
+  assets: {
+    assets: File[];
+    addAsset: (asset: File) => void;
+    removeAsset: (asset: File) => void;
+    setAssets: (assets: File[]) => void;
   };
   date?: Date;
   time?: string;
@@ -49,11 +49,11 @@ export const PosterContext = createContext<PosterContextProps>({
     removePresenter: (presenter) => {},
     setPresenters: (presenters) => {},
   },
-  pictures: {
-    pictures: [],
-    addPicture: (picture) => {},
-    removePicture: (picture) => {},
-    setPictures: (pictures) => {},
+  assets: {
+    assets: [],
+    addAsset: (asset) => {},
+    removeAsset: (asset) => {},
+    setAssets: (assets) => {},
   },
   date: new Date(),
   setDate: () => {},
@@ -66,6 +66,8 @@ export const PosterContextProvider: FC<{ children: ReactNode }> = ({
     useState<keyof typeof colorItemVariants>("primary");
   const [topics, setTopics] = useState<string[]>([]);
   const [presenters, setPresenters] = useState<string[]>([]);
+  const [assets, setAssets] = useState<File[]>([]);
+
   const [date, setDate] = useState<Date>();
   const [time, setTime] = useState<string>();
 
@@ -93,6 +95,14 @@ export const PosterContextProvider: FC<{ children: ReactNode }> = ({
     );
   };
 
+  const addAsset = (asset: File) => {
+    setAssets((prevAssets) => [...prevAssets, asset]);
+  };
+
+  const removeAsset = (asset: File) => {
+    setAssets((prevAssets) => prevAssets.filter((a) => a !== asset));
+  };
+
   const providerValue = {
     posterForm,
     posterBg: {
@@ -110,6 +120,12 @@ export const PosterContextProvider: FC<{ children: ReactNode }> = ({
       addPresenter,
       removePresenter,
       setPresenters,
+    },
+    assets: {
+      assets,
+      addAsset,
+      removeAsset,
+      setAssets,
     },
     date,
     time,

--- a/src/context/poster.tsx
+++ b/src/context/poster.tsx
@@ -13,35 +13,51 @@ import { PostFormInputs } from "@/components/post-form/post-form";
 
 interface PosterContextProps {
   posterForm?: UseFormReturn<PostFormInputs, undefined, any>;
-  topics: string[];
-  presenters: string[];
-  pictures?: string[];
+  topics: {
+    topics: string[];
+    addTopic: (topic: string) => void;
+    removeTopic: (topic: string) => void;
+    setTopics: (topics: string[]) => void;
+  };
+  presenters: {
+    presenters: string[];
+    addPresenter: (presenter: string) => void;
+    removePresenter: (presenter: string) => void;
+    setPresenters: (presenters: string[]) => void;
+  };
+  pictures?: {
+    pictures: string[];
+    addPicture?: (picture: string) => void;
+    removePicture?: (picture: string) => void;
+    setPictures?: (pictures: string[]) => void;
+  };
   date?: Date;
   time?: string;
   setTime?: (time: string) => void;
   setDate: SelectSingleEventHandler;
-  addTopic: (topic: string) => void;
-  removeTopic: (topic: string) => void;
-  addPresenter: (presenter: string) => void;
-  removePresenter: (presenter: string) => void;
-  setTopics: (topics: string[]) => void;
-  setPresenters: (presenters: string[]) => void;
-  setPictures?: (pictures: string[]) => void;
 }
 
 export const PosterContext = createContext<PosterContextProps>({
-  topics: [],
-  presenters: [],
-  pictures: [],
+  topics: {
+    topics: [],
+    addTopic: (topic: string) => {},
+    removeTopic: (topic: string) => {},
+    setTopics: (topics: string[]) => {},
+  },
+  presenters: {
+    presenters: [],
+    addPresenter: (presenter: string) => {},
+    removePresenter: (presenter: string) => {},
+    setPresenters: (presenters: string[]) => {},
+  },
+  pictures: {
+    pictures: [],
+    addPicture: (picture: string) => {},
+    removePicture: (picture: string) => {},
+    setPictures: (pictures: string[]) => {},
+  },
   date: new Date(),
   setDate: () => {},
-  addTopic: (topic: string) => {},
-  removeTopic: (topic: string) => {},
-  addPresenter: (presenter: string) => {},
-  removePresenter: (presenter: string) => {},
-  setTopics: (topics: string[]) => {},
-  setPresenters: (presenters: string[]) => {},
-  setPictures: (pictures: string[]) => {},
 });
 
 export const PosterContextProvider: FC<{ children: ReactNode }> = ({
@@ -78,18 +94,22 @@ export const PosterContextProvider: FC<{ children: ReactNode }> = ({
 
   const providerValue = {
     posterForm,
-    topics,
-    presenters,
+    topics: {
+      topics,
+      addTopic,
+      removeTopic,
+      setTopics,
+    },
+    presenters: {
+      presenters,
+      addPresenter,
+      removePresenter,
+      setPresenters,
+    },
     date,
     time,
     setTime,
     setDate,
-    addTopic,
-    removeTopic,
-    addPresenter,
-    removePresenter,
-    setTopics,
-    setPresenters,
   };
 
   return (

--- a/src/context/poster.tsx
+++ b/src/context/poster.tsx
@@ -28,9 +28,9 @@ interface PosterContextProps {
   };
   assets: {
     assets: Asset[];
-    addAsset: (asset: Asset) => void;
-    removeAsset: (asset: Asset) => void;
-    setAssets: (assets: Asset[]) => void;
+    addAsset: (assetKey: string) => void;
+    removeAsset: (assetKey: string) => void;
+    setAssets: (assetKeys: Asset[]) => void;
   };
   date?: Date;
   time?: string;
@@ -108,12 +108,16 @@ export const PosterContextProvider: FC<{ children: ReactNode }> = ({
     );
   };
 
-  const addAsset = (asset: Asset) => {
+  const addAsset = (assetKey: string) => {
+    const asset = assetsQuery.data?.find((a) => a.key === assetKey);
+
+    if (!asset) return;
+
     setAssets((prevAssets) => [...prevAssets, asset]);
   };
 
-  const removeAsset = (asset: Asset) => {
-    setAssets((prevAssets) => prevAssets.filter((a) => a !== asset));
+  const removeAsset = (assetKey: string) => {
+    setAssets((prevAssets) => prevAssets.filter((a) => a.key !== assetKey));
   };
 
   const providerValue = {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,12 +1,19 @@
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { ReactQueryDevtools } from "react-query/devtools";
 
 import { PosterContextProvider } from "@/context/poster";
 
+const queryClient = new QueryClient();
+
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <PosterContextProvider>
-      <Component {...pageProps} />
-    </PosterContextProvider>
+    <QueryClientProvider client={queryClient}>
+      <PosterContextProvider>
+        <Component {...pageProps} />
+      </PosterContextProvider>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   );
 }

--- a/src/pages/api/images.ts
+++ b/src/pages/api/images.ts
@@ -1,0 +1,14 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { utapi } from "uploadthing/server";
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  const files = await utapi.listFiles();
+
+  const imageKeys = files.map(({ key }) => key);
+
+  const images = await utapi.getFileUrls(imageKeys);
+
+  res.status(200).json(images);
+};
+
+export default handler;

--- a/src/pages/api/uploadthing.ts
+++ b/src/pages/api/uploadthing.ts
@@ -1,0 +1,7 @@
+import { createNextPageApiHandler } from "uploadthing/next-legacy";
+
+import { ourFileRouter } from "@/server/uploadthing";
+
+const handler = createNextPageApiHandler({ router: ourFileRouter });
+
+export default handler;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,11 +9,11 @@ const poppins = Poppins({ weight: ["400", "700"], subsets: ["latin"] });
 export default function Home() {
   return (
     <main
-      className={`bg-primary text-primary-foreground flex gap-6 min-h-screen flex-col items-center justify-center ${poppins.className}`}
+      className={`flex min-h-screen flex-col items-center justify-center gap-6 bg-primary px-2 text-primary-foreground md:px-0 ${poppins.className}`}
     >
       <FullNameEmphasis>POST GENERATOR</FullNameEmphasis>
-      <div className="grid grid-cols-2 gap-2">
-        <h2 className="col-span-full text-center text-2xl">
+      <div className="grid w-full grid-cols-1 gap-2 px-2 md:w-2/3 md:grid-cols-2">
+        <h2 className="col-span-full text-center text-base md:text-xl">
           Selecciona el tipo de post que quieres generar
         </h2>
         <HomeScreenLink href="/flyer">Posters</HomeScreenLink>
@@ -32,7 +32,7 @@ const HomeScreenLink: FC<LinkProps> = ({ href, children }) => {
   return (
     <Link
       href={href}
-      className="bg-white text-primary text-lg block rounded-sm px-4 py-2 text-center transition-all hover:brightness-75"
+      className="block rounded-sm bg-white px-4 py-2 text-center text-lg text-primary transition-all hover:brightness-75"
     >
       {children}
     </Link>

--- a/src/server/uploadthing.ts
+++ b/src/server/uploadthing.ts
@@ -1,0 +1,15 @@
+// import type { NextApiRequest, NextApiResponse } from "next";
+import { createUploadthing, type FileRouter } from "uploadthing/next-legacy";
+
+const f = createUploadthing();
+
+export const ourFileRouter = {
+  imageUploader: f({ image: { maxFileSize: "4MB" } }).onUploadComplete(
+    async ({ metadata, file }) => {
+      console.log("Upload complete: ", metadata);
+      console.log("File URL: ", file.url);
+    },
+  ),
+} satisfies FileRouter;
+
+export type OurFileRouter = typeof ourFileRouter;

--- a/src/utils/uploadthing.ts
+++ b/src/utils/uploadthing.ts
@@ -1,0 +1,6 @@
+import { generateComponents } from "@uploadthing/react";
+
+import type { OurFileRouter } from "@/server/uploadthing";
+
+export const { UploadButton, UploadDropzone, Uploader } =
+  generateComponents<OurFileRouter>();

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,12 +1,14 @@
+const { withUt } = require("uploadthing/tw");
+
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+module.exports = withUt({
   darkMode: ["class"],
   content: [
-    './pages/**/*.{ts,tsx}',
-    './components/**/*.{ts,tsx}',
-    './app/**/*.{ts,tsx}',
-    './src/**/*.{ts,tsx}',
-	],
+    "./pages/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./app/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}",
+  ],
   theme: {
     container: {
       center: true,
@@ -73,4 +75,4 @@ module.exports = {
     },
   },
   plugins: [require("tailwindcss-animate")],
-}
+});

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,6 +17,9 @@ module.exports = withUt({
         "2xl": "1400px",
       },
     },
+    fontFamily: {
+      sans: ["Poppins", "sans-serif"],
+    },
     extend: {
       colors: {
         border: "hsl(var(--border))",


### PR DESCRIPTION
## Describe your changes

This PR adds a way for users to upload custom assets to use them in the selected template. Additionally, it changes the poster's form by splitting it into accordion items to reduce cluttering, and adding both the assets input and a color selector.

### Update August 29

Improved the way state keeps track of rendered assets. Added `react-rnd` to use as a wrapper component for rendered assets, allowing the user to resize and move them around.

## What was done in this pull request

- [x] Added color selector.
- [x] Split form into accordion items.
- [x] Add assets input.
- [x] Preview uploaded assets in the template.
- [x] Ability to resize and move uploaded assets inside the template.

## Demo / Screenshot / Video

![image](https://github.com/CSIPro/post-generator/assets/39208827/aaf3a1c2-181a-452c-a263-3d603ed26d2c)
Form split into accordion items.

![image](https://github.com/CSIPro/post-generator/assets/39208827/3dddb955-1066-45cf-86ef-a5cdc6e821bd)
Asset upload form and uploaded assets, as well as highlighted items which means they're rendered in the template.

![image](https://github.com/CSIPro/post-generator/assets/39208827/ff5a3dd3-9bbd-4a6b-9432-e079a398db33)
Assets rendered in the template and a highlighted one, which happens when the item is being hovered over.
